### PR TITLE
dell::openmanage::redhat: resolve dependency cycle

### DIFF
--- a/manifests/openmanage/redhat.pp
+++ b/manifests/openmanage/redhat.pp
@@ -25,7 +25,7 @@ class dell::openmanage::redhat {
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dell\n\tfile:///etc/pki/rpm-gpg/RPM-GPG-KEY-libsmbios",
-    require    => [Package["firmware-addon-dell"], File["/etc/pki/rpm-gpg/RPM-GPG-KEY-dell"], File["/etc/pki/rpm-gpg/RPM-GPG-KEY-libsmbios"]],
+    require    => [File["/etc/pki/rpm-gpg/RPM-GPG-KEY-dell"], File["/etc/pki/rpm-gpg/RPM-GPG-KEY-libsmbios"]],
   }
 
   # ensure file is managed in case we want to purge /etc/yum.repos.d/


### PR DESCRIPTION
There was a dependency cycle when installing redhat on physical servers.
Removing that dependency breaks that cycle.

I'm not exactly sure why this dependency was there in the first place. It seems
weird that a repository definition depends on a package. The openmanage recipes
seem to apply just fine without this require.
