### PR TITLE
dell::openmanage: kill probable dependency cycle

### DIFF
--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -57,7 +57,6 @@ class dell::openmanage {
               "set /files/etc/yum/pluginconf.d/dellsysidplugin.conf/main/enabled 0",
               "set /files/etc/yum/pluginconf.d/dellsysid.conf/main/enabled 0"],
             require => Service["dataeng"],
-            notify  => Exec["update yum cache"],
           }
 
         }


### PR DESCRIPTION
We have a general puppet rule that packages depend on yum cache cleaning.
So we can't clean yum cache after installing a package that depends on that
yum cache cleaning. Anyway, it's fine if that plugin is disabled for the next
puppet run or user action. We don't need yum to clean its cache right now so
we can safely get rid of that notification.
