### PR TITLE
Add script to check warranty on Dell site

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,14 @@ class dell::params {
     default => $dell_omsa_version,
   }
 
+  $customplugins = $dell_customplugins ? {
+         '' => '/usr/local/src',
+    default => $dell_customplugins,
+  }
+
+  $check_warranty_revision = $dell_check_warranty_revision ? {
+    ''      => '42d157c57b1247e651021098b278adf14e468805',
+    default => $dell_check_warranty_revision,
+  }
+
 }

--- a/manifests/warranty.pp
+++ b/manifests/warranty.pp
@@ -1,0 +1,32 @@
+#
+# == Class: dell::warranty
+#
+# Install a script to check warranty of a product.
+# Used by the fact in this module
+#
+# See http://gitorious.org/smarmy/check_dell_warranty
+#
+class dell::warranty {
+
+  include dell::params
+
+  vcsrepo { "$::dell::params::customplugins/dell_warranty":
+    ensure   => present,
+    provider => git,
+    source   => "https://git.gitorious.org/smarmy/check_dell_warranty.git",
+    revision => "$::dell::params::check_warranty_revision",
+  }
+
+  file { "$::dell::params::customplugins/dell_warranty/check_dell_warranty.py":
+    ensure  => present,
+    mode    => 0755,
+    require => Vcsrepo[ "$::dell::params::customplugins/dell_warranty" ],
+  }
+
+  file { '/usr/local/sbin/check_dell_warranty.py':
+    ensure  => link,
+    target  => "$::dell::params::customplugins/dell_warranty/check_dell_warranty.py",
+    require => File["$::dell::params::customplugins/dell_warranty/check_dell_warranty.py"],
+  }
+
+}


### PR DESCRIPTION
The script revision was missing in params.
Add the script used by the fact to get the warranty.
