### PR TITLE
Allow OMSA 7.2 to work with RHEL 6.4

### DIFF
--- a/files/etc/init.d/dsm_sa_ipmi.RedHat.6.4
+++ b/files/etc/init.d/dsm_sa_ipmi.RedHat.6.4
@@ -1,0 +1,629 @@
+#!/bin/sh
+# File managed by Puppet (modified by Camptocamp to run under RHEL 6.4)
+#############################################################################
+#
+# dsm_sa_ipmi:	OpenIPMI Driver init script
+#
+# Authors:	Matt Domsch <Matt_Domsch@dell.com>
+#               Chris Poblete <Chris_Poblete@dell.com>
+#
+# chkconfig: - 04 96
+# description: OpenIPMI Driver init script
+#
+### BEGIN INIT INFO
+# Provides: dsm_sa_ipmi
+# Required-Start: $localfs $remotefs $syslog
+# Required-Stop: $localfs $remotefs $syslog
+# Default-Start:
+# Default-Stop:
+# Short-Description: OpenIPMI Driver init script
+# Description: OpenIPMI Driver init script
+### END INIT INFO
+#
+# Status return code bits
+# no bits set = no errors
+# bit 0 set = minimum modules aren't loaded
+# bit 1 set = requested feature module isn't loaded
+# bit 2 set = /dev/ipmi0 (or /dev/imb if using that instead) doesn't exist
+# bit 3 set = /dev/watchdog doesn't exist
+# bit 4 set = lockfile doesn't exist
+# bit 5 set = modules are loaded even when asked to be unloaded
+
+#
+#############################################################################
+# for log_success_msg and friends
+if [ -r /lib/lsb/init-functions ]; then
+# LSB, SLES, ...
+    . /lib/lsb/init-functions
+elif [ -r /etc/init.d/functions ]; then
+# Red Hat / VMware
+    . /etc/init.d/functions
+    my_log_message()
+    {
+	ACTION=$1
+	shift
+	
+	case "$ACTION" in
+	    success)
+		echo -n $*
+		success "$*"
+		echo
+		;;
+	    failure)
+		echo -n $*
+		failure "$*"
+		echo
+		;;
+	    warning)
+		echo -n $*
+		warning "$*"
+		echo
+		;;
+	    *)
+		;;
+	esac
+    }
+    log_success_msg()
+    {
+	my_log_message success "$*"
+    }
+    log_failure_msg()
+    {
+	my_log_message failure "$*"
+    }
+    log_warning_msg()
+    {
+	my_log_message warning "$*"
+    }
+fi
+
+CONFIGFILE=/etc/sysconfig/dsm_sa_ipmi
+# source config info
+[ -r ${CONFIGFILE} ] && . ${CONFIGFILE}
+
+#############################################################################
+# GLOBALS
+#############################################################################
+MODULE_NAME="dsm_sa_ipmi"
+INTF_NUM=0
+
+IPMI_SMB_MODULE_NAME="ipmi_smb"
+IPMI_SI_MODULE_NAME="ipmi_si"
+kernel=`uname -r | cut -d. -f1-2`
+if [ "${kernel}" == "2.4" ]; then
+    IPMI_SMB_MODULE_NAME="ipmi_smb_intf"
+    IPMI_SI_MODULE_NAME="ipmi_si_drv"
+fi
+
+MODULES_INTERFACES=""
+[ "${DEV_IPMI}" = "yes" ] && MODULES_INTERFACES="${MODULES_INTERFACES} ipmi_devintf"
+[ "${IPMI_IMB}" = "yes" ] && MODULES_INTERFACES="${MODULES_INTERFACES} ipmi_imb"
+
+MODULES_FEATURES=""
+[ "${IPMI_WATCHDOG}" = "yes" ] && MODULES_FEATURES="${MODULES_FEATURES} ipmi_watchdog"
+[ "${IPMI_POWEROFF}" = "yes" ] && MODULES_FEATURES="${MODULES_FEATURES} ipmi_poweroff"
+
+MODULES_HW=""
+[ "${IPMI_SI}"  = "yes" ] && MODULES_HW="${MODULES_HW} ${IPMI_SI_MODULE_NAME}"
+[ "${IPMI_SMB}" = "yes" ] && MODULES_HW="${MODULES_HW} ${IPMI_SMB_MODULE_NAME}"
+
+MODULES_BASE="ipmi_msghandler"
+MODULES="${MODULES_INTERFACES} ${MODULES_FEATURES} ${MODULES_HW} ${MODULES_BASE}"
+
+RETVAL=0
+LOCKFILE=/var/lock/subsys/ipmi
+DEV_IPMI_TIMEOUT=150
+
+UDEV_EXISTS=0
+if [ -e /sbin/udev -o -e /sbin/udevd ]; then
+    UDEV_EXISTS=1
+fi
+
+
+#############################################################################
+# NOTES:
+# * /dev/ipmi0 is unconditionally deleted here on ipmi_devintf unload,
+#   because SLES9 and RHEL4 kernels don't send a message for udev to delete
+#   it for us.
+# 
+#############################################################################
+
+modules_loaded_verbose()
+{
+	OnePlusLoaded=0
+	OnePlusUnloaded=0
+	for m in $@; do
+		if /sbin/lsmod | grep $m >/dev/null 2>&1 ; then
+			echo "$m module loaded."
+			OnePlusLoaded=1
+		elif [ -d "/sys/module/$m" ]; then
+			echo "$m module in kernel."
+			OnePlusLoaded=1
+		elif [ "$m" == "ipmi_msghandler" ]; then
+			if [ -d "/sys/module/ipmi_si" ]; then
+				echo "$m module in kernel."
+				OnePlusLoaded=1
+			else
+				OnePlusUnloaded=1
+			fi
+		else
+			echo "$m module not loaded."
+			OnePlusUnloaded=1
+		fi
+	done
+}
+
+modules_loaded()
+{
+	OnePlusLoaded=0
+	OnePlusUnloaded=0
+	for m in $@; do
+		if /sbin/lsmod | grep $m >/dev/null 2>&1 ; then
+			OnePlusLoaded=1
+		elif [ -d "/sys/module/$m" ]; then
+			OnePlusLoaded=1
+		elif [ "$m" == "ipmi_msghandler" ]; then
+			if [ -d "/sys/module/ipmi_si" ]; then
+				OnePlusLoaded=1
+			else
+				OnePlusUnloaded=1
+			fi
+		else
+			OnePlusUnloaded=1
+		fi
+	done
+}
+
+modules_unloaded()
+{
+	OnePlusLoaded=0
+	OnePlusUnloaded=0
+	for m in $@; do
+		if /sbin/lsmod | grep $m >/dev/null 2>&1 ; then
+			OnePlusLoaded=1
+		elif [ -d "/sys/module/$m" ]; then
+			OnePlusUnloaded=1
+		elif [ "$m" == "ipmi_msghandler" ]; then
+			if [ -d "/sys/module/ipmi_si" ]; then
+				OnePlusUnloaded=1 # XXX: compiled in kernel
+			else
+				OnePlusUnloaded=1
+			fi
+		else
+			OnePlusUnloaded=1
+		fi
+	done
+}
+
+device_node_exists ()
+{
+	if [ -e "$1" ]; then
+		echo "$1 exists."
+		return 1
+	fi
+	echo "$1 does not exist."
+	return 0
+}
+
+minimum_modules_loaded()
+{
+        rc_base=1
+	rc_hw=1
+        modules_loaded_verbose "${MODULES_BASE}"
+	[ ${OnePlusLoaded} -eq 0 ] && rc_base=0
+	    
+	modules_loaded_verbose "${MODULES_HW}"
+	[ ${OnePlusLoaded} -eq 0 ] && rc_hw=0
+	
+	return $((rc_base && rc_hw))
+}
+
+#############################################################################
+
+load_si()
+{
+	if [ "${IPMI_SI}" = "yes" ]; then
+		modprobe ${IPMI_SI_MODULE_NAME} > /dev/null 2>&1
+		modules_loaded ${IPMI_SI_MODULE_NAME}
+		[ ${OnePlusLoaded} -ne 1 ] && RETVAL=$((RETVAL | 1))
+	fi
+}
+
+load_smb()
+{
+	if [ "${IPMI_SMB}" = "yes" ]; then
+		modprobe ${IPMI_SMB_MODULE_NAME} > /dev/null 2>&1
+		modules_loaded ${IPMI_SMB_MODULE_NAME}
+		[ ${OnePlusLoaded} -ne 1 ] && RETVAL=$((RETVAL | 1))
+	fi
+}
+
+load_hw_modules()
+{
+	load_si
+	load_smb
+}
+
+start_watchdog_common()
+{
+	load_hw_modules
+	modprobe ipmi_watchdog ${IPMI_WATCHDOG_OPTIONS} > /dev/null 2>&1
+	modules_loaded ipmi_watchdog
+	[ ${OnePlusUnloaded} -ne 0 ] &&
+		RETVAL=$((RETVAL | 2)) &&
+		log_failure_msg &&
+		return
+	if [ ${UDEV_EXISTS} -eq 0 -a ! -e /dev/watchdog ]; then
+		mknod -m 0600 /dev/watchdog c 10 130
+		[ $? -ne 0 ] &&
+			RETVAL=$((RETVAL | 8)) &&
+			log_failure_msg &&
+			return
+	fi
+	log_success_msg
+}
+
+start_watchdog_quiet()
+{
+	[ "${IPMI_WATCHDOG}" != "yes" ] &&
+		return
+	echo -n $"Starting ipmi_watchdog driver: "
+	start_watchdog_common
+}
+
+start_watchdog()
+{
+	echo -n $"Starting ipmi_watchdog driver: "
+	[ "${IPMI_WATCHDOG}" != "yes" ] &&
+		RETVAL=$((RETVAL | 2)) &&
+		log_failure_msg "not configured" &&
+		return
+	start_watchdog_common
+}
+
+stop_watchdog()
+{
+	echo -n $"Stopping ipmi_watchdog driver: "
+	modprobe -q -r ipmi_watchdog > /dev/null 2>&1
+	modules_loaded ipmi_watchdog
+	if [ ${OnePlusLoaded} -ne 0 ]; then
+	    RETVAL=$((RETVAL | 32))
+	    log_failure_msg
+	else
+	    if [ "${IPMI_WATCHDOG}" = "yes" ]; then
+		[ ${UDEV_EXISTS} -eq 0 ] && rm -f /dev/watchdog
+	    fi
+	    log_success_msg
+	fi
+}
+
+stop_watchdog_quiet()
+{
+	modprobe -q -r ipmi_watchdog > /dev/null 2>&1
+	modules_loaded ipmi_watchdog
+	if [ ${OnePlusLoaded} -ne 0 ]; then
+	    RETVAL=$((RETVAL | 32))
+	else
+	    if [ "${IPMI_WATCHDOG}" = "yes" ]; then
+		[ ${UDEV_EXISTS} -eq 0 ] && rm -f /dev/watchdog
+	    fi
+	fi
+}
+
+start_powercontrol_common()
+{
+	local poweroff_opts=""
+	load_hw_modules
+	if [ "${IPMI_POWERCYCLE}" == "yes" ]; then
+	    modinfo ipmi_poweroff 2>/dev/null | grep poweroff_control > /dev/null 2>&1 && \
+		poweroff_opts="poweroff_control=2"
+	    modinfo ipmi_poweroff 2>/dev/null | grep poweroff_powercycle > /dev/null 2>&1 && \
+		poweroff_opts="poweroff_powercycle=1"
+	fi
+	modprobe ipmi_poweroff "${poweroff_opts}" > /dev/null 2>&1
+	modules_loaded ipmi_poweroff
+	[ ${OnePlusUnloaded} -ne 0 ] &&
+		RETVAL=$((RETVAL | 2)) &&
+		log_failure_msg &&
+		return
+	log_success_msg
+}
+
+start_powercontrol_quiet()
+{
+	[ "${IPMI_POWEROFF}" != "yes" ] &&
+		return
+	echo -n $"Starting ipmi_poweroff driver: "
+	start_powercontrol_common
+}
+
+start_powercontrol()
+{
+	echo -n $"Starting ipmi_poweroff driver: "
+	[ "${IPMI_POWEROFF}" != "yes" ] &&
+		RETVAL=$((RETVAL | 2)) &&
+		log_failure_msg "not configured" &&
+		return
+	start_powercontrol_common
+}
+
+stop_powercontrol()
+{
+	echo -n $"Stopping ipmi_poweroff driver: "
+	modprobe -q -r ipmi_poweroff > /dev/null 2>&1
+	modules_loaded ipmi_poweroff
+	if [ ${OnePlusLoaded} -ne 0 ]; then
+	    RETVAL=$((RETVAL | 32))
+	    log_failure_msg
+	else
+	    log_success_msg
+	fi
+}
+
+stop_powercontrol_quiet()
+{
+	modprobe -q -r ipmi_poweroff > /dev/null 2>&1
+	modules_loaded ipmi_poweroff
+	[ ${OnePlusLoaded} -ne 0 ] && RETVAL=$((RETVAL | 32))
+}
+
+#############################################################################
+unload_all_ipmi_modules()
+{
+	stop_watchdog_quiet
+	stop_powercontrol_quiet
+	for m in ${MODULES}; do
+		modprobe -q -r ${m} > /dev/null 2>&1
+	done
+        # delete interface node ONLY if ipmi_devintf is unloaded
+        [ `lsmod | grep -c "ipmi_devintf"` -eq 0 ] &&
+	        rm -f "/dev/ipmi${INTF_NUM}"
+}
+
+unload_ipmi_modules_leave_features()
+{
+	for m in ${MODULES_INTERFACES}; do
+		modprobe -q -r ${m} > /dev/null 2>&1
+	done
+        # delete interface node ONLY if ipmi_devintf is unloaded
+        [ `lsmod | grep -c "ipmi_devintf"` -eq 0 ] &&
+	        rm -f "/dev/ipmi${INTF_NUM}"
+	lsmod | egrep -q "ipmi_(poweroff|watchdog)" > /dev/null 2>&1
+	if [ "$?" -ne "0" ]; then
+		stop_watchdog_quiet
+		stop_powercontrol_quiet
+		for m in ${MODULES}; do
+			modprobe -q -r ${m} > /dev/null 2>&1
+		done
+	fi
+}
+
+#############################################################################
+load_ipmi_modules ()
+{
+	local locdelay
+	modprobe ipmi_msghandler > /dev/null 2>&1
+	modules_loaded ipmi_msghandler
+	[ ${OnePlusLoaded} -ne 1 ] && unload_all_ipmi_modules && RETVAL=$((RETVAL | 1)) && return
+	load_hw_modules
+	[ $((RETVAL & 1)) -eq 1 ] && unload_all_ipmi_modules && RETVAL=$((RETVAL | 1)) && return
+
+	if [ "${DEV_IPMI}" = "yes" ]; then
+		modprobe ipmi_devintf > /dev/null 2>&1
+		modules_loaded ipmi_devintf
+		RETVAL=$((RETVAL & ~2))
+		[ ${OnePlusLoaded} -eq 0 ] && RETVAL=$((RETVAL | 2))
+		if [ ${OnePlusLoaded} -eq 1 ]; then
+			if [ ${UDEV_EXISTS} -eq 0 ]; then
+				DEVMAJOR=`cat /proc/devices | awk '/ipmidev/{print $1}'`
+				rm -f /dev/ipmi${INTF_NUM}
+				mknod -m 0600 /dev/ipmi${INTF_NUM} c ${DEVMAJOR} 0 || RETVAL=$((RETVAL | 4))
+			fi
+
+			# udev can take several seconds to create /dev/ipmi0, 
+			# but it happens asynchronously, so delay here
+			locdelay=${DEV_IPMI_TIMEOUT}
+			while [ ! -e /dev/ipmi${INTF_NUM} -a ${locdelay} -gt 0 ]; do
+				locdelay=$((locdelay - 1))
+				sleep 1
+			done
+		fi
+	fi
+
+	if [ "${IPMI_IMB}" = "yes" ]; then
+		modprobe ipmi_imb > /dev/null 2>&1
+		modules_loaded ipmi_imb
+		RETVAL=$((RETVAL & ~2))
+		[ ${OnePlusLoaded} -eq 0 ] && RETVAL=$((RETVAL | 2))
+		if [ ${OnePlusLoaded} -eq 1 ]; then
+			DEVMAJOR=`cat /proc/devices | awk '/imb/{print $1}'`
+			rm -f /dev/imb
+			mknod -m 0600 /dev/imb c ${DEVMAJOR} 0 || RETVAL=$((RETVAL | 4))
+		fi
+	fi
+
+	# Per Corey Minyard, essentially no one uses ipmi_radisys
+	# and we don't want to encourage its further use
+	# so it won't be handled here.
+	return
+}
+
+#############################################################################
+start()
+{
+	echo -n "Starting ${MODULE_NAME} drivers: "
+	load_ipmi_modules
+	if [ ${RETVAL} -eq 0 ]; then
+		touch ${LOCKFILE} && log_success_msg
+	else
+		if [ $((RETVAL & 1)) -eq 1 ]; then
+			log_failure_msg
+		else
+			touch ${LOCKFILE} && log_warning_msg
+		fi
+	fi
+	start_watchdog_quiet
+	start_powercontrol_quiet
+}
+
+#############################################################################
+stop()
+{
+	echo -n "Stopping ${MODULE_NAME} drivers: "
+	unload_ipmi_modules_leave_features
+	modules_loaded ${MODULES_INTERFACES}
+	if [ ${OnePlusLoaded} -ne 0 ]; then
+		RETVAL=$((RETVAL | 32))
+		log_failure_msg "may be in use"
+	else
+		rm -f ${LOCKFILE}
+		log_success_msg
+	fi
+}
+
+stop_all()
+{
+	echo -n $"Stopping all ${MODULE_NAME} drivers: "
+	unload_all_ipmi_modules
+	modules_loaded ${MODULES}
+	if [ ${OnePlusLoaded} -ne 0 ]; then
+		RETVAL=$((RETVAL | 32))
+		log_failure_msg "may be in use"
+	else
+		rm -f ${LOCKFILE}
+		log_success_msg
+	fi
+}
+
+#############################################################################
+restart()
+{
+	stop_all
+	RETVAL=0
+	start
+}
+
+#############################################################################
+
+reload()
+{
+	stop_all
+	RETVAL=0
+	start
+}
+
+#############################################################################
+
+status_all()
+{
+	minimum_modules_loaded
+	[ $? -eq 0 ] && RETVAL=$((RETVAL | 1))
+	
+	modules_loaded_verbose ${MODULES_FEATURES} ${MODULES_INTERFACES}
+	[ ${OnePlusUnloaded} -ne 0 ] && RETVAL=$((RETVAL | 2))
+
+	if [ "${DEV_IPMI}" = "yes" ]; then 
+	    device_node_exists /dev/ipmi${INTF_NUM}
+	    [ $? -eq 0 ] && RETVAL=$((RETVAL | 4))
+	fi
+
+	if [ "${IPMI_IMB}" = "yes" ]; then
+	    device_node_exists /dev/imb
+	    [ $? -eq 0 ] && RETVAL=$((RETVAL | 4))
+	fi
+
+	if [ "${IPMI_WATCHDOG}" = "yes" ]; then
+	    device_node_exists /dev/watchdog
+	    [ $? -eq 0 ] && RETVAL=$((RETVAL | 8))
+	fi
+
+	[ ! -e ${LOCKFILE} ] && RETVAL=$((RETVAL | 16))
+}
+
+status()
+{
+	minimum_modules_loaded
+	[ $? -eq 0 ] && RETVAL=$((RETVAL | 1))
+	
+	if [ "${DEV_IPMI}" = "yes" ]; then 
+	    modules_loaded_verbose ipmi_devintf
+	    [ ${OnePlusLoaded} -eq 0 ] && RETVAL=$((RETVAL | 2))
+
+	    device_node_exists /dev/ipmi${INTF_NUM}
+	    [ $? -eq 0 ] && RETVAL=$((RETVAL | 4))
+	fi
+
+	if [ "${IPMI_IMB}" = "yes" ]; then
+	    device_node_exists /dev/imb
+	    [ $? -eq 0 ] && RETVAL=$((RETVAL | 4))
+	fi
+}
+
+status_watchdog()
+{
+	minimum_modules_loaded
+	[ $? -eq 0 ] && RETVAL=$((RETVAL | 1))
+
+	modules_loaded_verbose ipmi_watchdog
+	[ ${OnePlusLoaded} -eq 0 ] && RETVAL=$((RETVAL | 2))
+
+	device_node_exists /dev/watchdog
+	[ $? -eq 0 ] && RETVAL=$((RETVAL | 8))
+}
+
+status_powercontrol()
+{
+	minimum_modules_loaded
+	[ $? -eq 0 ] && RETVAL=$((RETVAL | 1))
+
+	modules_loaded_verbose ipmi_powercontrol
+	[ ${OnePlusLoaded} -eq 0 ] && RETVAL=$((RETVAL | 2))
+}
+
+#############################################################################
+usage ()
+{
+	echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart" 1>&2
+	echo $"          start-watchdog|stop-watchdog|status-watchdog" 1>&2
+	echo $"          start-powercontrol|stop-powercontrol|status-powercontrol" 1>&2
+	echo $"          stop-all|status-all}" 1>&2
+	echo $"" 1>&2
+	echo $"CAUTION: Please do not use this when ipmi or openipmi init is present." 1>&2
+	echo $"" 1>&2
+	RETVAL=1
+}
+
+condrestart ()
+{
+	[ -e ${LOCKFILE} ] && restart
+}
+
+#############################################################################
+# MAIN
+#############################################################################
+case "$1" in
+	start) start ;;
+	stop)  stop ;;
+	restart) restart ;;
+	force-reload) reload ;;
+	reload) reload ;;
+	status)	status ;;
+	status-all) status_all ;;
+	condrestart) condrestart ;;
+	try-restart) condrestart ;;
+	start-watchdog) start_watchdog ;;
+	stop-watchdog) stop_watchdog ;;
+	status-watchdog) status_watchdog ;;
+	start-powercontrol) start_powercontrol ;;
+	stop-powercontrol) stop_powercontrol ;;
+	status-powercontrol) status_powercontrol ;;
+	stop-all) stop_all ;;
+	*) usage ;;
+esac
+
+exit ${RETVAL}
+
+#############################################################################
+# end of file
+#############################################################################
+

--- a/manifests/openmanage/redhat.pp
+++ b/manifests/openmanage/redhat.pp
@@ -52,4 +52,26 @@ class dell::openmanage::redhat {
     ensure => absent,
   }
 
+  # Patch for RHEL6.4, waiting for new OMSA release
+  # See http://lists.us.dell.com/pipermail/linux-poweredge/2013-March/047794.html
+  # This file is a kind a merge between /etc/init.d/ipmi (provided by OpenIPMI)
+  # and /etc/init.d/dsm_sa_ipmi (provided by OMSA 7.2)
+  case $::lsbdistrelease {
+
+    '6.4': {
+      file { '/etc/init.d/dsm_sa_ipmi':
+        ensure  => present,
+        source  => "puppet:///modules/dell/etc/init.d/dsm_sa_ipmi.${::osfamily}.${::lsbdistrelease}",
+        mode    => '0755',
+        seluser => 'system_u',
+        selrole => 'object_r',
+        seltype => 'initrc_exec_t',
+        before  => [ Service['dataeng'] ],
+      }
+    }
+
+    default: {}
+
+  }
+
 }


### PR DESCRIPTION
Provide a patched version of /etc/init.d/dsm_sa_ipmi, waiting next OMSA release.
I hope we can revert this patch asap.
