### PR TITLE
Fact for Express Service Code

### DIFF
--- a/lib/facter/dell_express_service_code.rb
+++ b/lib/facter/dell_express_service_code.rb
@@ -1,4 +1,4 @@
-Facter.add('dell_expressservicecode') do
+Facter.add('dell_express_service_code') do
   confine :id => 'root'
   confine :is_virtual => 'false'
   if !Facter.value(:manufacturer).nil? and Facter.value(:manufacturer).match(/dell/i)


### PR DESCRIPTION
As in the Dell documentation:
"Express Service Code
A numeric code located on a sticker on your Dell™ computer. This code is a mathematical conversion of the computer’s Service Tag Number into a purely numeric format allowing for easy entry into Dell's automated call-routing system."

It use the serialnumber fact and just convert it to decimal base.
Usefull to call Dell support.
