### PR TITLE
Add a dell class, make it mandatory to get parameters

### DIFF
--- a/manifests/hwtools.pp
+++ b/manifests/hwtools.pp
@@ -5,7 +5,11 @@
 #
 class dell::hwtools {
 
-  include dell::params
+  if (!defined(Class['dell'])) {
+    fail 'You need to declare class dell'
+  }
+
+  include ::dell::params
 
   # Dans ces paquets, on trouve de quoi flasher et extraires des infos des
   # bios & firmwares.
@@ -36,7 +40,7 @@ class dell::hwtools {
       # http://linux.dell.com/wiki/index.php/Repository/software
       yumrepo {'dell-omsa-indep':
         descr      => 'Dell OMSA repository - Hardware independent',
-        mirrorlist => "${::dell::params::omsa_url_base}${::dell::params::omsa_version}/mirrors.cgi?${::dell::params::omsa_url_args_indep}",
+        mirrorlist => "${dell::omsa_url_base}${dell::omsa_version}/mirrors.cgi?${dell::omsa_url_args_indep}",
         enabled    => 1,
         gpgcheck   => 1,
         gpgkey     => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dell\n\tfile:///etc/pki/rpm-gpg/RPM-GPG-KEY-libsmbios",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,20 @@
+class dell (
+  $omsa_url_base = $dell::params::omsa_url_base,
+  $omsa_url_args_indep = $dell::params::omsa_url_args_indep,
+  $omsa_url_args_specific = $dell::params::omsa_url_args_specific,
+  $omsa_version = $dell::params::omsa_version,
+  $customplugins = $dell::params::customplugins,
+  $check_warranty_revision = $dell::params::check_warranty_revision,
+) inherits ::dell::params {
+
+  validate_uri($omsa_url_base)
+  validate_string($omsa_url_args_indep)
+  validate_string($omsa_url_args_specific)
+
+  validate_string($omsa_version)
+
+  validate_string($customplugins)
+  validate_absolute_path($customplugins)
+
+  validate_string($check_warranty_revision)
+}

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -5,7 +5,7 @@
 #
 class dell::openmanage {
 
-  include dell::hwtools
+  include ::dell::hwtools
 
   service { 'dataeng':
     ensure    => running,
@@ -44,7 +44,7 @@ class dell::openmanage {
       # openmanage is a mess to install on redhat, and recent versions
       # don't support older hardware. So puppet will install it if absent,
       # or else leave it unmanaged.
-      include dell::openmanage::redhat
+      include ::dell::openmanage::redhat
 
       augeas { 'disable dell yum plugin once OM is installed':
         changes => [
@@ -57,11 +57,11 @@ class dell::openmanage {
     }
 
     Debian: {
-      include dell::openmanage::debian
+      include ::dell::openmanage::debian
     }
 
     default: {
-      err("Unsupported operatingsystem: $::operatingsystem.")
+      err("Unsupported operatingsystem: ${::operatingsystem}.")
     }
 
   }

--- a/manifests/openmanage/debian.pp
+++ b/manifests/openmanage/debian.pp
@@ -5,21 +5,25 @@
 #
 class dell::openmanage::debian {
 
+  if (!defined(Class['dell'])) {
+    fail 'You need to declare class dell'
+  }
+
   # key of:
   # http://linux.dell.com/repo/community/deb/OMSA_7.0/ (same for 7.1)
   # necessary for 6.5
-  $key_34D8786F=$::dell::params::omsa_version?{
+  $key_34D8786F = $dell::omsa_version ? {
     'OMSA_6.5' => 'present',
     'OMSA_7.0' => 'present',
     'OMSA_7.1' => 'present',
     'latest'   => 'present',
-            '' => 'present',
+    ''         => 'present',
     default    => 'absent',
   }
 
   # key of:
   # http://linux.dell.com/repo/community/deb/OMSA_6.5/
-  $key_5E3D7775=$::dell::params::omsa_version?{
+  $key_5E3D7775 = $dell::omsa_version ? {
     'OMSA_6.5' => 'present',
     default    => 'absent',
   }
@@ -168,15 +172,15 @@ SNnmxzdpR6pYJGbEDdFyZFe5xHRWSlrC3WTbzg==
   }
 
   $sources_list_content = $::lsbdistcodename ? {
-    /lenny/ => "deb ftp://ftp.sara.nl/pub/sara-omsa dell6 sara\n",
-  /squeeze/ => "deb ${::dell::params::omsa_url_base}${::dell::params::omsa_version} /\n",
-   default  => "deb http://linux.dell.com/repo/community/debian ${::lsbdistcodename} openmanage",
+    'lenny'   => "deb ftp://ftp.sara.nl/pub/sara-omsa dell6 sara\n",
+    'squeeze' => "deb ${dell::omsa_url_base}${dell::omsa_version} /\n",
+    default   => "deb http://linux.dell.com/repo/community/debian ${::lsbdistcodename} openmanage",
   }
 
   $omsa_pkg_name = $::lsbdistcodename ? {
-    /lenny/ => 'dellomsa',
-  /squeeze/ => [ 'srvadmin-base', 'srvadmin-storageservices' ],
-    default => [ 'srvadmin-base', 'srvadmin-storageservices', 'srvadmin-omcommon' ],
+    'lenny'   => 'dellomsa',
+    'squeeze' => [ 'srvadmin-base', 'srvadmin-storageservices' ],
+    default   => [ 'srvadmin-base', 'srvadmin-storageservices', 'srvadmin-omcommon' ],
   }
 
   apt::sources_list {'dell':

--- a/manifests/openmanage/redhat.pp
+++ b/manifests/openmanage/redhat.pp
@@ -5,7 +5,9 @@
 #
 class dell::openmanage::redhat {
 
-  include dell::params
+  if (!defined(Class['dell'])) {
+    fail 'You need to declare class dell'
+  }
 
   # this package contains the yum plugin which find the best yum repository
   # depending on the hardware.
@@ -25,7 +27,7 @@ class dell::openmanage::redhat {
   # http://linux.dell.com/repo/hardware/latest
   yumrepo {'dell-omsa-specific':
     descr      => 'Dell OMSA repository - Hardware specific',
-    mirrorlist => "${::dell::params::omsa_url_base}${::dell::params::omsa_version}/mirrors.cgi?${::dell::params::omsa_url_args_specific}",
+    mirrorlist => "${dell::omsa_url_base}${dell::omsa_version}/mirrors.cgi?${dell::omsa_url_args_specific}",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-dell\n\tfile:///etc/pki/rpm-gpg/RPM-GPG-KEY-libsmbios",

--- a/manifests/warranty.pp
+++ b/manifests/warranty.pp
@@ -8,25 +8,27 @@
 #
 class dell::warranty {
 
-  include dell::params
-
-  vcsrepo { "$::dell::params::customplugins/dell_warranty":
-    ensure   => present,
-    provider => git,
-    source   => "https://git.gitorious.org/smarmy/check_dell_warranty.git",
-    revision => "$::dell::params::check_warranty_revision",
+  if (!defined(Class['dell'])) {
+    fail 'You need to declare class dell'
   }
 
-  file { "$::dell::params::customplugins/dell_warranty/check_dell_warranty.py":
+  vcsrepo { "${dell::customplugins}/dell_warranty":
+    ensure   => present,
+    provider => git,
+    source   => 'https://git.gitorious.org/smarmy/check_dell_warranty.git',
+    revision => $dell::check_warranty_revision,
+  }
+
+  file { "${dell::customplugins}/dell_warranty/check_dell_warranty.py":
     ensure  => present,
-    mode    => 0755,
-    require => Vcsrepo[ "$::dell::params::customplugins/dell_warranty" ],
+    mode    => '0755',
+    require => Vcsrepo[ "${dell::customplugins}/dell_warranty" ],
   }
 
   file { '/usr/local/sbin/check_dell_warranty.py':
     ensure  => link,
-    target  => "$::dell::params::customplugins/dell_warranty/check_dell_warranty.py",
-    require => File["$::dell::params::customplugins/dell_warranty/check_dell_warranty.py"],
+    target  => "${dell::customplugins}/dell_warranty/check_dell_warranty.py",
+    require => File["${dell::customplugins}/dell_warranty/check_dell_warranty.py"],
   }
 
 }


### PR DESCRIPTION
This requires to do an `include ::dell` before using the module's classes. Once migrated internally, we can get rid of global variables in `dell::params`.
