### PR TITLE
Change to $::osfamily to add proper Ubuntu detection.

### DIFF
--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -38,8 +38,8 @@ class dell::openmanage {
     recurse => true,
   }
 
-  case $::operatingsystem {
-    /RedHat|CentOS/: {
+  case $::osfamily {
+    RedHat: {
 
       # openmanage is a mess to install on redhat, and recent versions
       # don't support older hardware. So puppet will install it if absent,
@@ -61,7 +61,7 @@ class dell::openmanage {
     }
 
     default: {
-      err("Unsupported operatingsystem: ${::operatingsystem}.")
+      err("Unsupported operatingsystem: ${::osfamily}.")
     }
 
   }

--- a/spec/classes/dell_spec.rb
+++ b/spec/classes/dell_spec.rb
@@ -10,4 +10,22 @@ describe 'dell' do
 
   it { should compile.with_all_deps }
 
+  let(:facts) {{
+    :lsbdistcodename => 'trusty',
+    :osfamily        => 'Debian',
+    :operatingsystem => 'Ubuntu',
+    :productname     => 'foo',
+  }}
+
+  it { should compile.with_all_deps }
+
+  let(:facts) {{
+    :lsbdistcodename => nil,
+    :osfamily        => 'RedHat',
+    :operatingsystem => 'CentOS',
+    :productname     => 'foo',
+  }}
+
+  it { should compile.with_all_deps }
+
 end


### PR DESCRIPTION
The dell::openmanage class incorrectly assumes that Ubuntu operatingsystems
will return Debian, when the actually return Ubuntu.
    
This fix moves to using $::osfamily instead of $::operatingsystem
in order to correctly handle Ubuntu hosts when trying to setup
the repo.