### PR TITLE
dell: repo name change again

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,10 +8,38 @@ class dell::params {
   case $::osfamily {
 
     'RedHat': {
-      $omsa_url_base = 'http://linux.dell.com/repo/hardware/'
-      $omsa_url_args_indep = 'osname=el$releasever&basearch=$basearch&native=1&dellsysidpluginver=$dellsysidpluginver'
-      $omsa_url_args_specific = 'osname=el$releasever&basearch=$basearch&native=1&sys_ven_id=$sys_ven_id&sys_dev_id=$sys_dev_id&dellsysidpluginver=$dellsysidpluginver'
-    }
+      case $::operatingsystemmajrelease {
+        /^[5|6]$/: {
+          $omsa_url_base = 'http://linux.dell.com/repo/hardware/'
+          $omsa_url_args_indep = 'osname=el$releasever&basearch=$basearch&native=1&dellsysidpluginver=$dellsysidpluginver'
+          $omsa_url_args_specific = 'osname=el$releasever&basearch=$basearch&native=1&sys_ven_id=$sys_ven_id&sys_dev_id=$sys_dev_id&dellsysidpluginver=$dellsysidpluginver'
+          $omsa_version = $::productname ? {
+            'PowerEdge 1750'    => 'OMSA_6.1',
+            'PowerEdge 1850'    => 'OMSA_5.5',
+            'PowerEdge 1950'    => 'OMSA_6.1',
+            'PowerEdge 2950'    => 'OMSA_6.4',
+            'PowerEdge R210 II' => 'OMSA_6.4',
+            'PowerEdge R310'    => 'OMSA_6.4',
+            'PowerEdge R410'    => 'OMSA_6.4',
+            'PowerEdge R510'    => 'OMSA_6.4',
+            'PowerEdge R610'    => 'OMSA_6.4',
+            'PowerEdge T320'    => '',
+            'PowerEdge R620'    => 'OMSA_7.2',
+            default             => 'latest',
+          }
+        }
+
+        default: {
+          $omsa_url_base = 'http://linux.dell.com/repo/hardware/'
+          $omsa_url_args_indep = 'osname=el$releasever&basearch=$basearch&native=1&dellsysidpluginver=$dellsysidpluginver'
+          $omsa_url_args_specific = 'osname=el$releasever&basearch=$basearch&native=1&sys_ven_id=$sys_ven_id&sys_dev_id=$sys_dev_id&dellsysidpluginver=$dellsysidpluginver'
+          $omsa_version = $::productname ? {
+            default    => 'Linux_Repository_15.04.00',
+          }
+        } #default
+
+      }
+    } # RedHat
 
     'Debian': {
       $omsa_url_base = $::lsbdistcodename ? {
@@ -28,24 +56,24 @@ class dell::params {
       $omsa_url_args_indep = ''
       $omsa_url_args_specific = ''
       # lint:endignore
-    }
+      $omsa_version = $::productname ? {
+        'PowerEdge 1750'    => 'OMSA_6.1',
+        'PowerEdge 1850'    => 'OMSA_5.5',
+        'PowerEdge 1950'    => 'OMSA_6.1',
+        'PowerEdge 2950'    => 'OMSA_6.4',
+        'PowerEdge R210 II' => 'OMSA_6.4',
+        'PowerEdge R310'    => 'OMSA_6.4',
+        'PowerEdge R410'    => 'OMSA_6.4',
+        'PowerEdge R510'    => 'OMSA_6.4',
+        'PowerEdge R610'    => 'OMSA_6.4',
+        'PowerEdge T320'    => '',
+        'PowerEdge R620'    => 'OMSA_7.2',
+        default             => 'latest',
+      }
+
+    } # Debian
 
     default:  { fail("Unsupported OS family: ${::osfamily}") }
-  }
-
-  $omsa_version = $::productname ? {
-    'PowerEdge 1750'    => 'OMSA_6.1',
-    'PowerEdge 1850'    => 'OMSA_5.5',
-    'PowerEdge 1950'    => 'OMSA_6.1',
-    'PowerEdge 2950'    => 'OMSA_6.4',
-    'PowerEdge R210 II' => 'OMSA_6.4',
-    'PowerEdge R310'    => 'OMSA_6.4',
-    'PowerEdge R410'    => 'OMSA_6.4',
-    'PowerEdge R510'    => 'OMSA_6.4',
-    'PowerEdge R610'    => 'OMSA_6.4',
-    'PowerEdge T320'    => '',
-    'PowerEdge R620'    => 'OMSA_7.2',
-    default             => 'latest',
   }
 
   $customplugins = '/usr/local/src'

--- a/spec/classes/dell_spec.rb
+++ b/spec/classes/dell_spec.rb
@@ -20,10 +20,31 @@ describe 'dell' do
   it { should compile.with_all_deps }
 
   let(:facts) {{
-    :lsbdistcodename => nil,
-    :osfamily        => 'RedHat',
-    :operatingsystem => 'CentOS',
-    :productname     => 'foo',
+    :lsbdistcodename           => nil,
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemmajrelease => '5',
+    :productname               => 'foo',
+  }}
+
+  it { should compile.with_all_deps }
+
+  let(:facts) {{
+    :lsbdistcodename           => nil,
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemmajrelease => '6',
+    :productname               => 'foo',
+  }}
+
+  it { should compile.with_all_deps }
+
+  let(:facts) {{
+    :lsbdistcodename           => nil,
+    :osfamily                  => 'RedHat',
+    :operatingsystem           => 'CentOS',
+    :operatingsystemmajrelease => '7',
+    :productname               => 'foo',
   }}
 
   it { should compile.with_all_deps }


### PR DESCRIPTION
Required to handle RedHat7.

There is an issue with version 8.1.0-4.94.3.el7 shipped in
Linux_Repository_15.04.00. Discussion and workaround here:
http://lists.us.dell.com/pipermail/linux-poweredge/2015-May/049784.html