### PR TITLE
Allow changes of the git remote in the warranty repo

### DIFF
--- a/manifests/warranty.pp
+++ b/manifests/warranty.pp
@@ -8,6 +8,7 @@
 #
 class dell::warranty (
   $ensure = present,
+  $git_remote = 'https://github.com/gcmalloc/puppet-dell.git',
 ) {
 
   validate_re($ensure, '^(present|absent)$',
@@ -20,7 +21,7 @@ class dell::warranty (
   vcsrepo { "${dell::customplugins}/dell_warranty":
     ensure   => $ensure,
     provider => git,
-    source   => 'https://git.gitorious.org/smarmy/check_dell_warranty.git',
+    source   => $git_remote,
     revision => $dell::check_warranty_revision,
   }
 


### PR DESCRIPTION
As the git repository used to fetch the warranty script is down,
this changes permit the user to change the repository to another one.

I can move the parameter to the init and params if you want to.