### PR TITLE
debian jessie : use wheezy repository

### DIFF
--- a/manifests/openmanage/debian.pp
+++ b/manifests/openmanage/debian.pp
@@ -197,6 +197,14 @@ SNnmxzdpR6pYJGbEDdFyZFe5xHRWSlrC3WTbzg==
         include_src => false,
       }
     }
+    'jessie': {
+      apt::source{'dell':
+        location    => 'http://linux.dell.com/repo/community/debian',
+        release     => 'wheezy',
+        repos       => 'openmanage',
+        include_src => false,
+      }
+    }
     default: {
       apt::source{'dell':
         location    => 'http://linux.dell.com/repo/community/debian',


### PR DESCRIPTION
Currently dell don't provide jessie repository.

wheezy repository works perfectly with jessie, so simply use it