### PR TITLE
Fixed US-ASCII encoding issue due to french accents in comments

### DIFF
--- a/manifests/openmanage/redhat.pp
+++ b/manifests/openmanage/redhat.pp
@@ -28,8 +28,8 @@ class dell::openmanage::redhat(
     before  => Service['dataeng'],
   }
 
-  # Ce repo héberge openmanage, mais dépendent d'un plugin yum qui
-  # va analyser le hardware et échoue si le système n'est pas supporté.
+  # This repo hosts openmanage but is dependent from a plugin that is
+  # going to analyse the harware and will fail if the system is not supported
   #
   if $dell_repo {
     # http://linux.dell.com/repo/hardware/latest


### PR DESCRIPTION
I had to fix this in order to avoid this error on RedHat based systems :

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: invalid byte sequence in US-ASCII at /etc/puppet/modules/dell/manifests/openmanage/redhat.pp:1 on node
```
