### PR TITLE
Use smbios-utils instead of libsmbios-bin for wheezy

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,8 +48,8 @@ class dell::params {
       }
 
       $smbios_pkg = $::lsbdistcodename ? {
-        /lenny|squeeze|wheezy/ => 'libsmbios-bin',
-        default                => 'smbios-utils',
+        /lenny|squeeze/ => 'libsmbios-bin',
+        default         => 'smbios-utils',
       }
 
       # lint:ignore:empty_string_assignment


### PR DESCRIPTION
The svnadmin-* packages on Wheezy require smbios-utils. Fixes #66.