### PR TITLE
Wrap warranties in an array if not already an array

### DIFF
--- a/lib/facter/warranty.rb
+++ b/lib/facter/warranty.rb
@@ -21,7 +21,10 @@ Facter.add(:warranty_end) do
 
   setcode do
     enddate = Date.parse(Time.at(0).to_s)
-    Facter::Util::Warranty.warranties.each do |warranty|
+    warranties = Facter::Util::Warranty.warranties
+    warranties = [warranties] unless warranties.is_a?(Array)
+
+    warranties.each do |warranty|
       if Date.parse(warranty['EndDate']) > enddate
         enddate = Date.parse(warranty['EndDate'])
       end


### PR DESCRIPTION
It's possible that the Dell API call returns only one warranty. When
this is the case, the warranties value is a hash and not an array. This
breaks the 'warranty_end' fact (which in turn breaks the
'warranty_days_left' fact).