### PR TITLE
added option to disable "include ::apt"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,10 +1,11 @@
 class dell (
-  $omsa_url_base = $dell::params::omsa_url_base,
-  $omsa_url_args_indep = $dell::params::omsa_url_args_indep,
-  $omsa_url_args_specific = $dell::params::omsa_url_args_specific,
-  $omsa_version = $dell::params::omsa_version,
-  $customplugins = $dell::params::customplugins,
+  $omsa_url_base           = $dell::params::omsa_url_base,
+  $omsa_url_args_indep     = $dell::params::omsa_url_args_indep,
+  $omsa_url_args_specific  = $dell::params::omsa_url_args_specific,
+  $omsa_version            = $dell::params::omsa_version,
+  $customplugins           = $dell::params::customplugins,
   $check_warranty_revision = $dell::params::check_warranty_revision,
+  $manage_debian_apt       = $dell::params::manage_debian_apt,
 ) inherits ::dell::params {
 
   validate_string($omsa_url_base)

--- a/manifests/openmanage/debian.pp
+++ b/manifests/openmanage/debian.pp
@@ -5,7 +5,9 @@
 #
 class dell::openmanage::debian {
 
-  include ::apt
+  if ($::dell::manage_debian_apt) {
+    include ::apt
+  }
 
   if (!defined(Class['dell'])) {
     fail 'You need to declare class dell'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,6 +78,8 @@ class dell::params {
 
   $customplugins = '/usr/local/src'
 
+  $manage_debian_apt = true
+
   $check_warranty_revision = '42d157c57b1247e651021098b278adf14e468805'
 
 }


### PR DESCRIPTION
If one wants to set parameters for the apt class elsewhere, the include creates a conflict.
The added Option allows to disable the include.