### PR TITLE
Use default section as Ubuntu 16.04 Xenial is now supported by Dell repos

### DIFF
--- a/manifests/openmanage/debian.pp
+++ b/manifests/openmanage/debian.pp
@@ -226,9 +226,6 @@ SNnmxzdpR6pYJGbEDdFyZFe5xHRWSlrC3WTbzg==
         },
       }
     }
-    'xenial': {
-      fail('Ubuntu 16.04 is not supported by Dell')
-    }
     default: {
       apt::source{'dell':
         location => 'http://linux.dell.com/repo/community/debian',


### PR DESCRIPTION
18.04 and other releases still not supported, however, so they stay as failure cases.