### PR TITLE
Don't clobber existing warranty fact cache with invalid data

### DIFF
--- a/lib/facter/warranty.rb
+++ b/lib/facter/warranty.rb
@@ -63,7 +63,7 @@ def create_dell_warranty_cache(cache)
   # Skip writing warranty if cache file already exists and we haven't got info this time..
   # This avoids clobbering the cache with invalid info when we get an invalid response
   if File.file?(cache) && expiration_date == orig_exp_date
-    Facter.debug('warranty cache: invalid data received from Dell API, not updating..')
+    Facter.debug('warranty cache: invalid data received from Dell API, not updating.')
   else
     File.open(cache, 'w') do |file|
       YAML.dump({'warranty_status' => warranty,

--- a/lib/facter/warranty.rb
+++ b/lib/facter/warranty.rb
@@ -13,6 +13,7 @@ def create_dell_warranty_cache(cache)
 
   warranty        = false
   expiration_date = Time.parse('1901-01-01T00:00:00')
+  orig_exp_date   = expiration_date
   start_date      = Time.now() # Push start time back and expiration forward
   servicetag      = Facter.value('serialnumber')
 
@@ -59,11 +60,17 @@ def create_dell_warranty_cache(cache)
 
   warranty = true if expiration_date > Time.now()
 
-  File.open(cache, 'w') do |file|
-    YAML.dump({'warranty_status' => warranty,
-               'start_date'      => start_date.strftime("%Y-%m-%d"),
-               'expiration_date' => expiration_date.strftime("%Y-%m-%d")},
-              file)
+  # Skip writing warranty if cache file already exists and we haven't got info this time..
+  # This avoids clobbering the cache with invalid info when we get an invalid response
+  if File.file?(cache) && expiration_date == orig_exp_date
+    Facter.debug('warranty cache: invalid data received from Dell API, not updating..')
+  else
+    File.open(cache, 'w') do |file|
+      YAML.dump({'warranty_status' => warranty,
+                 'start_date'      => start_date.strftime("%Y-%m-%d"),
+                 'expiration_date' => expiration_date.strftime("%Y-%m-%d")},
+                file)
+    end
   end
 end
 

--- a/manifests/openmanage/debian.pp
+++ b/manifests/openmanage/debian.pp
@@ -226,9 +226,6 @@ SNnmxzdpR6pYJGbEDdFyZFe5xHRWSlrC3WTbzg==
         },
       }
     }
-    'xenial': {
-      fail('Ubuntu 16.04 is not supported by Dell')
-    }
     default: {
       apt::source{'dell':
         location => 'http://linux.dell.com/repo/community/debian',


### PR DESCRIPTION
The warranty fact cache was being reset to contain the default date of 1901-01-01 if the Dell API call appeared to succeed but then failed to get any valid warranty data.

This change stops the cache being written to if the default expiration date hasn't been updated.