### PR TITLE
change debian repository and add focal support

### DIFF
--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -10,11 +10,6 @@ class dell::openmanage (
 
   include ::dell::hwtools
 
-  service { 'dataeng':
-    ensure    => $service_ensure,
-    hasstatus => true,
-  }
-
   file {'/etc/logrotate.d/openmanage':
     ensure  => file,
     owner   => root,
@@ -72,10 +67,37 @@ class dell::openmanage (
         notify  => Service['dataeng'],
         require => Package['srvadmin-storageservices'],
       }
+
+      service { 'dataeng':
+        ensure    => $service_ensure,
+        hasstatus => true,
+        tag       => 'dell',
+      }
+
     }
 
     'Debian': {
       include ::dell::openmanage::debian
+
+      if $dell::openmanage::debian::ver >= 950 {
+        service { 'dsm_sa_datamgrd':
+          ensure    => $service_ensure,
+          hasstatus => true,
+          tag       => 'dell',
+        }
+
+        service { 'dsm_sa_eventmgrd':
+          ensure    => $service_ensure,
+          hasstatus => true,
+          tag       => 'dell',
+        }
+      } else {
+        service { 'dataeng':
+          ensure    => $service_ensure,
+          hasstatus => true,
+          tag       => 'dell',
+        }
+      }
     }
 
     default: {

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -80,16 +80,12 @@ class dell::openmanage (
       include ::dell::openmanage::debian
 
       if $dell::openmanage::debian::ver >= 950 {
-        service { 'dsm_sa_datamgrd':
-          ensure    => $service_ensure,
-          hasstatus => true,
-          tag       => 'dell',
-        }
-
-        service { 'dsm_sa_eventmgrd':
-          ensure    => $service_ensure,
-          hasstatus => true,
-          tag       => 'dell',
+        ['datamgrd', 'eventmgrd', 'snmpd'].each |$_service| {
+          service { "dsm_sa_${_service}":
+            ensure    => $service_ensure,
+            hasstatus => true,
+            tag       => 'dell',
+          }
         }
       } else {
         service { 'dataeng':

--- a/manifests/openmanage.pp
+++ b/manifests/openmanage.pp
@@ -80,12 +80,10 @@ class dell::openmanage (
       include ::dell::openmanage::debian
 
       if $dell::openmanage::debian::ver >= 950 {
-        ['datamgrd', 'eventmgrd', 'snmpd'].each |$_service| {
-          service { "dsm_sa_${_service}":
-            ensure    => $service_ensure,
-            hasstatus => true,
-            tag       => 'dell',
-          }
+        service { [ 'dsm_sa_datamgrd', 'dsm_sa_eventmgrd', 'dsm_sa_snmpd' ]:
+          ensure    => $service_ensure,
+          hasstatus => true,
+          tag       => 'dell',
         }
       } else {
         service { 'dataeng':


### PR DESCRIPTION
Hello,

The dell repository change since OMSA v9.1.0 http://linux.dell.com/repo/community/openmanage/

I've tested on Ubuntu 20.04 and a PowerEdger R640.

They remove the service `dataeng` on my package (srvadmin-deng 9.5.0), but I've see 2 systemd service now `dsm_sa_eventmgrd` and `dsm_sa_datamgrd`